### PR TITLE
Dcos previous version

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -766,6 +766,7 @@ resource "aws_instance" "bootstrap" {
     dcos_overlay_mtu = "${var.dcos_overlay_mtu}"
     dcos_overlay_network = "${var.dcos_overlay_network}"
     dcos_process_timeout = "${var.dcos_process_timeout}"
+    dcos_previous_version = "${var.dcos_previous_version}"
     dcos_agent_list = "\n - ${join("\n - ", aws_instance.agent.*.private_ip)}"
     # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
     # Workaround is to flatten the list as a string below. Fix when this is closed.
@@ -841,6 +842,7 @@ resource "null_resource" "bootstrap" {
     dcos_overlay_mtu = "${var.dcos_overlay_mtu}"
     dcos_overlay_network = "${var.dcos_overlay_network}"
     dcos_process_timeout = "${var.dcos_process_timeout}"
+    dcos_previous_version = "${var.dcos_previous_version}"
     # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
     # Workaround is to flatten the list as a string below. Fix when this is closed.
     dcos_resolvers  = "\n - ${join("\n - ", var.dcos_resolvers)}"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -365,6 +365,11 @@ variable "dcos_process_timeout" {
  description = "This parameter specifies the allowable amount of time, in seconds, for an action to begin after the process forks. This parameter is not the complete process time. The default value is 120 seconds."
 }
 
+variable "dcos_previous_version" {
+ default = ""
+ description = "Required by the DC/OS installer instructions to ensure the operator know what version they are upgrading from."
+}
+
 variable "dcos_version" {
  default = "1.8.8"
  description = "DCOS Version"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -422,7 +422,7 @@ variable "dcos_package_storage_uri" {
 
 variable "dcos_previous_version" {
  default = ""
- description = "Required by the DC/OS installer instructions to ensure the operator know what version they are upgrading from"
+ description = "Required by the DC/OS installer instructions to ensure the operator know what version they are upgrading from."
 }
 
 # Example value on how to configure rexray below

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -422,7 +422,8 @@ variable "dcos_package_storage_uri" {
 
 variable "dcos_previous_version" {
  default = ""
- description = "Required by the DC/OS installer instructions to ensure the operator know what version they are upgrading from"}
+ description = "Required by the DC/OS installer instructions to ensure the operator know what version they are upgrading from"
+}
 
 # Example value on how to configure rexray below
 # default = "{\"rexray\": {\"modules\": {\"default-docker\": {\"disabled\": true}, \"default-admin\": {\"host\": \"tcp://127.0.0.1:61003\"}}, \"loglevel\": \"info\"}}"


### PR DESCRIPTION
successfully installed and upgraded from 1.9.4 to 1.10.0 while using dcos_previous_version. 