### PR TITLE
DC/OS 1.10.0 + CoreOS 1465.8.0 + AWS profile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+*.plan
+/aws/.terraform.tfstate.lock.info

--- a/aws/README.md
+++ b/aws/README.md
@@ -96,7 +96,7 @@ When reading the instructions below regarding installing and upgrading, you can 
 
 ## Installing DC/OS
 
-If you wanted to install a specific version of DC/OS you can either use the stable versions or early access. You can also pick and choose any version if you like when you're first starting out. On the section below, this will explain how you automate upgrades when you're ready along with changing what order you would like them upgraded. 
+If you wanted to install a specific version of DC/OS you can either use the stable versions or early access. You can also pick and choose any version if you like when you're first starting out. On the section below, this will explain how you automate upgrades when you're ready along with changing what order you would like them upgraded.
 
 ### DC/OS Stable (1.8.8)
 ```bash
@@ -115,9 +115,9 @@ terraform apply
 
 ### Config.yaml Modification
 
-You can modify all the DC/OS config.yaml flags via terraform. Here is an example of using the master_http_loadbalancer for cloud deployments. **master_http_loadbalancer is recommended for production**. You will be able to replace your masters in a multi master environment. Using the default static backend will not give you this option. 
+You can modify all the DC/OS config.yaml flags via terraform. Here is an example of using the master_http_loadbalancer for cloud deployments. **master_http_loadbalancer is recommended for production**. You will be able to replace your masters in a multi master environment. Using the default static backend will not give you this option.
 
-Here is an example default profile that will allow you to do this. 
+Here is an example default profile that will allow you to do this.
 
 ```bash
 $ cat desired_cluster_profile
@@ -133,9 +133,9 @@ dcos_exhibitor_storage_backend = "aws_s3"
 dcos_exhibitor_explicit_keys = "true"
 ```
 
-**NOTE:** This will append your aws_access_key_id and aws_secret_access_key key in your config.yaml on your bootstrap node so DC/OS will know how to upload its state to the aws_s3 bucket. 
+**NOTE:** This will append your aws_access_key_id and aws_secret_access_key key in your config.yaml on your bootstrap node so DC/OS will know how to upload its state to the aws_s3 bucket.
 
-## Upgrading DC/OS  
+## Upgrading DC/OS
 
 You can upgrade your DC/OS cluster with a single command. This terraform script was built to perform installs and upgrade from the inception of this project. With the upgrade procedures below, you can also have finer control on how masters or agents upgrade at a given time. This will give you the ability to change the parallelism of master or agent upgrades.
 
@@ -145,11 +145,11 @@ You can upgrade your DC/OS cluster with a single command. This terraform script 
 
 **Important**: DC/OS will is not designed to upgrade directly from disabled to strict. Please be responsible when using automation tools.
 
-This command below will upgrade your masters and agents one at a time. It takes roughly 5 minutes per node, so depending on how many nodes, you may want to consider changing your parallelism to change the speed of your upgrade. 
+This command below will upgrade your masters and agents one at a time. It takes roughly 5 minutes per node, so depending on how many nodes, you may want to consider changing your parallelism to change the speed of your upgrade.
 
 **Prioritise Master Upgrades First**
 
-If you take this route, you can use a few more commands but this will allow you upgrade your master nodes first, one at a time, then upgrade the agents simuanioustly with the next. Terraforms parallel algorithm will walk the graph in any order. It may do one agent first, a master second, etc. You would need to target your master resource so you can upgrade the masters first then change the parallelism back to any number for the agents. 
+If you take this route, you can use a few more commands but this will allow you upgrade your master nodes first, one at a time, then upgrade the agents simuanioustly with the next. Terraforms parallel algorithm will walk the graph in any order. It may do one agent first, a master second, etc. You would need to target your master resource so you can upgrade the masters first then change the parallelism back to any number for the agents.
 
 **Master upgrade sequentially one at a time**
 ```bash
@@ -170,7 +170,7 @@ terraform apply \
 --var state=upgrade \
 --var dcos_security=disabled
   ```
-  
+
   *NOTE: the default for parallelism is 10. You can change this value to control how many nodes you want upgraded at any given time*
 
 
@@ -233,7 +233,7 @@ terraform apply \
 
 ## Maintenance
 
-If you would like to add more or remove (private) agents or public agents from your cluster, you can do so by telling terraform your desired state and it will make sure it gets you there. For example, if I have 2 private agents and 1 public agent in my `-var-file` I can always override that flag by specifying the `-var` flag. It has higher priority than the `-var-file`. 
+If you would like to add more or remove (private) agents or public agents from your cluster, you can do so by telling terraform your desired state and it will make sure it gets you there. For example, if I have 2 private agents and 1 public agent in my `-var-file` I can always override that flag by specifying the `-var` flag. It has higher priority than the `-var-file`.
 
 ### Adding Agents
 
@@ -353,5 +353,3 @@ terraform destroy
   - [X] Support for RHEL
   - [ ] Secondary support for specific versions of RHEL
   - [ ] Multi AZ Support
-
-

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -123,7 +123,7 @@ resource "aws_security_group" "admin" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.admin_cidr}"]
   }
 
   # http access from anywhere
@@ -131,7 +131,7 @@ resource "aws_security_group" "admin" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.admin_cidr}"]
   }
 
   # httpS access from anywhere
@@ -139,7 +139,7 @@ resource "aws_security_group" "admin" {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.admin_cidr}"]
   }
 
   # outbound internet access
@@ -171,7 +171,7 @@ resource "aws_security_group" "master" {
    to_port = 80
    from_port = 80
    protocol = "tcp"
-   cidr_blocks = ["0.0.0.0/0"]
+   cidr_blocks = ["${var.admin_cidr}"]
  }
 
  # Adminrouter SSL access from anywhere
@@ -179,7 +179,7 @@ resource "aws_security_group" "master" {
    to_port = 443
    from_port = 443
    protocol = "tcp"
-   cidr_blocks = ["0.0.0.0/0"]
+   cidr_blocks = ["${var.admin_cidr}"]
  }
 
  # Marathon access from within the vpc

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,5 +1,6 @@
 # Specify the provider and access details
 provider "aws" {
+  profile = "${var.aws_profile}"
   region = "${var.aws_region}"
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -71,14 +71,14 @@ resource "aws_security_group" "any_access_internal" {
   description = "Manage all ports cluster level"
   vpc_id      = "${aws_vpc.default.id}"
 
- # full access internally 
+ # full access internally
  ingress {
   from_port = 0
   to_port = 0
   protocol = "-1"
   cidr_blocks = ["${aws_vpc.default.cidr_block}"]
   }
-  
+
  # full access internally
  egress {
   from_port = 0
@@ -140,7 +140,7 @@ resource "aws_security_group" "admin" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   # outbound internet access
   egress {
     from_port   = 0
@@ -150,7 +150,7 @@ resource "aws_security_group" "admin" {
   }
 }
 
-# A security group for the ELB so it is accessible via the web 
+# A security group for the ELB so it is accessible via the web
 # with some master ports for internal access only
 resource "aws_security_group" "master" {
   name        = "master-security-group"
@@ -188,7 +188,7 @@ resource "aws_security_group" "master" {
    protocol = "tcp"
    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
  }
- 
+
  # Exhibitor access from within the vpc
  ingress {
    to_port = 8181
@@ -219,7 +219,7 @@ resource "aws_security_group" "public_slave" {
   name        = "public-slave-security-group"
   description = "security group for slave public"
   vpc_id      = "${aws_vpc.default.id}"
- 
+
   # Allow ports within range
   ingress {
     to_port = 21
@@ -235,7 +235,7 @@ resource "aws_security_group" "public_slave" {
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
- 
+
   # Allow ports within range
   ingress {
     to_port = 32000
@@ -243,7 +243,7 @@ resource "aws_security_group" "public_slave" {
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
- 
+
   # Allow ports within range
   ingress {
     to_port = 21
@@ -251,7 +251,7 @@ resource "aws_security_group" "public_slave" {
     protocol = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
- 
+
   # Allow ports within range
   ingress {
     to_port = 5050
@@ -259,7 +259,7 @@ resource "aws_security_group" "public_slave" {
     protocol = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
- 
+
   # Allow ports within range
   ingress {
     to_port = 32000
@@ -290,7 +290,7 @@ resource "aws_security_group" "private_slave" {
    protocol = "-1"
    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
    }
- 
+
   # full access internally
   egress {
    from_port = 0
@@ -337,14 +337,14 @@ resource "aws_elb" "internal-master-elb" {
     lb_protocol       = "http"
     instance_protocol = "http"
   }
-  
+
   listener {
     lb_port           = 80
     instance_port     = 80
     lb_protocol       = "tcp"
     instance_protocol = "tcp"
   }
-  
+
   listener {
     lb_port           = 443
     instance_port     = 443
@@ -358,7 +358,7 @@ resource "aws_elb" "internal-master-elb" {
     lb_protocol       = "http"
     instance_protocol = "http"
   }
- 
+
   lifecycle {
     ignore_changes = ["name"]
   }
@@ -466,14 +466,14 @@ resource "aws_instance" "master" {
 
     # The connection will use the local SSH agent for authentication.
   }
-  
+
   root_block_device {
     volume_size = "${var.instance_disk_size}"
   }
 
   count = "${var.num_of_masters}"
   instance_type = "${var.aws_master_instance_type}"
-  
+
   ebs_optimized  = "true"
 
   tags {
@@ -485,7 +485,7 @@ resource "aws_instance" "master" {
 
   # Lookup the correct AMI based on the region
   # we specified
-  ami = "${module.aws-tested-oses.aws_ami}"      
+  ami = "${module.aws-tested-oses.aws_ami}"
 
   # The name of our SSH keypair we created above.
   key_name = "${var.key_name}"
@@ -546,7 +546,7 @@ resource "aws_instance" "agent" {
   }
   # Lookup the correct AMI based on the region
   # we specified
-  ami = "${module.aws-tested-oses.aws_ami}"      
+  ami = "${module.aws-tested-oses.aws_ami}"
 
   # The name of our SSH keypair we created above.
   key_name = "${var.key_name}"
@@ -598,7 +598,7 @@ resource "aws_instance" "public-agent" {
   instance_type = "${var.aws_public_agent_instance_type}"
 
   ebs_optimized = "true"
- 
+
   tags {
    owner = "${coalesce(var.owner, data.external.whoami.result["owner"])}"
    expiration = "${var.expiration}"
@@ -607,7 +607,7 @@ resource "aws_instance" "public-agent" {
   }
   # Lookup the correct AMI based on the region
   # we specified
-  ami = "${module.aws-tested-oses.aws_ami}"      
+  ami = "${module.aws-tested-oses.aws_ami}"
 
   # The name of our SSH keypair we created above.
   key_name = "${var.key_name}"
@@ -667,7 +667,7 @@ resource "aws_instance" "bootstrap" {
 
   # Lookup the correct AMI based on the region
   # we specified
-  ami = "${module.aws-tested-oses.aws_ami}"      
+  ami = "${module.aws-tested-oses.aws_ami}"
 
   # The name of our SSH keypair we created above.
   key_name = "${var.key_name}"
@@ -701,7 +701,7 @@ resource "aws_instance" "bootstrap" {
       "sudo bash /tmp/os-setup.sh",
     ]
   }
- 
+
   lifecycle {
     ignore_changes = ["tags.Name"]
   }
@@ -719,7 +719,7 @@ resource "aws_instance" "bootstrap" {
     custom_dcos_download_path = "${var.custom_dcos_download_path}"
     # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
     # Workaround is to flatten the list as a string below. Fix when this is closed.
-    dcos_public_agent_list = "\n - ${join("\n - ", aws_instance.public-agent.*.private_ip)}" 
+    dcos_public_agent_list = "\n - ${join("\n - ", aws_instance.public-agent.*.private_ip)}"
     dcos_audit_logging = "${var.dcos_audit_logging}"
     dcos_auth_cookie_secure_flag = "${var.dcos_auth_cookie_secure_flag}"
     dcos_aws_access_key_id = "${var.dcos_aws_access_key_id}"
@@ -755,7 +755,7 @@ resource "aws_instance" "bootstrap" {
     dcos_log_directory = "${var.dcos_log_directory}"
     dcos_master_discovery = "${var.dcos_master_discovery}"
     dcos_master_dns_bindall = "${var.dcos_master_dns_bindall}"
-    # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings. 
+    # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
     # Workaround is to flatten the list as a string below. Fix when this is closed.
     dcos_master_list = "\n - ${join("\n - ", aws_instance.master.*.private_ip)}"
     dcos_no_proxy = "${var.dcos_no_proxy}"
@@ -781,7 +781,7 @@ resource "aws_instance" "bootstrap" {
     dcos_use_proxy = "${var.dcos_use_proxy}"
     dcos_zk_agent_credentials = "${var.dcos_zk_agent_credentials}"
     dcos_zk_master_credentials = "${var.dcos_zk_master_credentials}"
-    dcos_zk_super_credentials = "${var.dcos_zk_super_credentials}"    
+    dcos_zk_super_credentials = "${var.dcos_zk_super_credentials}"
     dcos_cluster_docker_registry_url = "${var.dcos_cluster_docker_registry_url}"
     dcos_rexray_config = "${var.dcos_rexray_config}"
     dcos_ip_detect_public_contents = "${var.dcos_ip_detect_public_contents}"
@@ -913,7 +913,7 @@ resource "null_resource" "master" {
   }
 
   count = "${var.num_of_masters}"
-  
+
   # Generate and upload Master script to node
   provisioner "file" {
     content     = "${module.dcos-mesos-master.script}"
@@ -923,7 +923,7 @@ resource "null_resource" "master" {
   # Wait for bootstrapnode to be ready
   provisioner "remote-exec" {
     inline = [
-     "until $(curl --output /dev/null --silent --head --fail http://${aws_instance.bootstrap.private_ip}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done" 
+     "until $(curl --output /dev/null --silent --head --fail http://${aws_instance.bootstrap.private_ip}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
   }
 
@@ -1037,4 +1037,3 @@ resource "null_resource" "public-agent" {
     ]
   }
 }
-

--- a/aws/modules/dcos-tested-aws-oses/platform/cloud/aws/coreos_1465.8.0/setup.sh
+++ b/aws/modules/dcos-tested-aws-oses/platform/cloud/aws/coreos_1465.8.0/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/aws/modules/dcos-tested-aws-oses/variables.tf
+++ b/aws/modules/dcos-tested-aws-oses/variables.tf
@@ -15,7 +15,7 @@ variable "aws_ami" {
  centos_7.3_us-west-2      = "ami-f4533694"
  coreos_835.13.0_us-west-2 = "ami-4f00e32f"
  coreos_1235.9.0_us-west-2 = "ami-4c49f22c"
+ coreos_1465.8.0_us-west-2 = "ami-82bd41fa" # HVM
  rhel_7.3_us-west-2        = "ami-b55a51cc"
  }
 }
-

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -18,6 +18,11 @@ variable "aws_profile" {
   default     = "default"
 }
 
+variable "admin_cidr" {
+  description = "Inbound Master Access"
+  default     = "0.0.0.0/0"
+}
+
 variable "os" {
   default = "coreos_1235.9.0"
   description = "Recommended DC/OS OSs are centos_7.2, coreos_1235.9.0, coreos_835.13.0"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -371,7 +371,7 @@ variable "dcos_process_timeout" {
 }
 
 variable "dcos_version" {
- default = "1.8.8"
+ default = "1.10.0"
  description = "DCOS Version"
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -13,6 +13,11 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
+variable "aws_profile" {
+  description = "AWS profile to use"
+  default     = "default"
+}
+
 variable "os" {
   default = "coreos_1235.9.0"
   description = "Recommended DC/OS OSs are centos_7.2, coreos_1235.9.0, coreos_835.13.0"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -44,7 +44,7 @@ variable "num_of_private_agents" {
 }
 
 variable "num_of_public_agents" {
-  description = "DC/OS Private Agents Count"
+  description = "DC/OS Public Agents Count"
   default = 1
 }
 
@@ -73,7 +73,7 @@ variable "ip-detect" {
 }
 
 variable "os-init-script" {
- description = "Init Scripts that runs post-AMI deployment and pre-DC/OS install" 
+ description = "Init Scripts that runs post-AMI deployment and pre-DC/OS install"
  type = "map"
 
  default = {
@@ -308,7 +308,7 @@ variable "dcos_overlay_network" {
 variable "dcos_dns_search" {
  default = ""
  description = "This parameter specifies a space-separated list of domains that are tried when an unqualified domain is entered"
-} 
+}
 
 variable "dcos_master_dns_bindall" {
  default = ""


### PR DESCRIPTION
A very mixed set of features, all checked via deployment into an AWS account.

- UPGRADE: DC/OS 1.10.0: 
Upgrade of the formally default version 1.8.8 to the most recent release

- UPGRADE: CoreOS 1465.8.0: 
Added support for the most recent stable version, only for AWS region us-west-2

- FEATURE: AWS profile
Added support to adjust the used AWS profile to support different AWS account settings on local machines.
