### PR TITLE
Variable for configuring the bootstrap disk size

### DIFF
--- a/aws/bootstrap.tf
+++ b/aws/bootstrap.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "bootstrap" {
   }
 
   root_block_device {
-    volume_size = "${var.instance_disk_size}"
+    volume_size = "${var.aws_bootstrap_instance_disk_size}"
   }
 
   instance_type = "${var.aws_bootstrap_instance_type}"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -48,6 +48,11 @@ variable "aws_bootstrap_instance_type" {
   default = "m3.large"
 }
 
+variable "aws_bootstrap_instance_disk_size" {
+  description = "AWS DC/OS bootstrap instance type default size of the root disk (GB)"
+  default = "60"
+}
+
 variable "num_of_private_agents" {
   description = "DC/OS Private Agents Count"
   default = 2


### PR DESCRIPTION
Added a variable that give you the flexibility to assign disk size of
the bootstrap node independently of the other nodes.

Previously the disk size of the bootstrap instance would be set the
same as the disk size of all the other nodes in the cluster. But the
bootstrap instance might not need to use as much disk space.