### PR TITLE
Added North Europe region to azure and fixing azurerm_storage_account

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -63,10 +63,11 @@ resource "azurerm_subnet" "private" {
 }
 
 resource "azurerm_storage_account" "dcos-exhibitor-account" {
-  name                = "tf${substr(md5(random_id.cluster.id),0,4)}exhibitor"
-  resource_group_name = "${azurerm_resource_group.dcos.name}"
-  location            = "${azurerm_resource_group.dcos.location}"
-  account_type        = "Standard_LRS"
+  name                     = "tf${substr(md5(random_id.cluster.id),0,4)}exhibitor"
+  resource_group_name      = "${azurerm_resource_group.dcos.name}"
+  location                 = "${azurerm_resource_group.dcos.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 
   tags {
    Name       = "${coalesce(var.owner, data.external.whoami.result["owner"])}"

--- a/azure/modules/dcos-tested-azure-oses/azure_variables.tf
+++ b/azure/modules/dcos-tested-azure-oses/azure_variables.tf
@@ -21,5 +21,6 @@ variable "azure_os_image_version" {
   "coreos_835.13.0_West US"   = ["CoreOS", "CoreOS", "Stable", "835.13.0"]
   "coreos_1235.9.0_West US"   = ["CoreOS", "CoreOS", "Stable", "1235.9.0"]
   "rhel_7.3_West US"          = ["RHEL", "RedHat", "7.3", "7.3.2017053118"]
+  "centos_7.3_North Europe"   = ["CentOS","OpenLogic","7.3","7.3.20170707"]
  }
 }


### PR DESCRIPTION
account_type is deprecated in azurerm_storage_account, it's now splitted to (account_tier, account_replication_type)

Also does it make sense to have different images for different regions in azure, or you can omit region part in azure_os_image_version mapping?