### PR TITLE
Set the root disk size of public agent/node

### DIFF
--- a/aws/master.tf
+++ b/aws/master.tf
@@ -116,7 +116,7 @@ resource "aws_instance" "master" {
   }
 
   root_block_device {
-    volume_size = "${var.instance_disk_size}"
+    volume_size = "${var.aws_master_instance_disk_size}"
   }
 
   count = "${var.num_of_masters}"

--- a/aws/private-agent.tf
+++ b/aws/private-agent.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "agent" {
   }
 
   root_block_device {
-    volume_size = "${var.instance_disk_size}"
+    volume_size = "${var.aws_agent_instance_disk_size}"
   }
 
   count = "${var.num_of_private_agents}"

--- a/aws/public-agent.tf
+++ b/aws/public-agent.tf
@@ -52,7 +52,7 @@ resource "aws_instance" "public-agent" {
   }
 
   root_block_device {
-    volume_size = "${var.instance_disk_size}"
+    volume_size = "${var.aws_public_agent_instance_disk_size}"
   }
 
   count = "${var.num_of_public_agents}"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -43,6 +43,11 @@ variable "aws_public_agent_instance_type" {
   default = "m3.xlarge"
 }
 
+variable "aws_public_agent_instance_disk_size" {
+  description = "AWS DC/OS Public instance type default size of the root disk (GB)"
+  default = "60"
+}
+
 variable "aws_bootstrap_instance_type" {
   description = "AWS DC/OS Bootstrap instance type"
   default = "m3.large"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -33,6 +33,11 @@ variable "aws_master_instance_type" {
   default = "m3.xlarge"
 }
 
+variable "aws_master_instance_disk_size" {
+  description = "AWS DC/OS Master instance type default size of the root disk (GB)"
+  default = "60"
+}
+
 variable "aws_agent_instance_type" {
   description = "AWS DC/OS Private Agent instance type"
   default = "m3.xlarge"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -43,6 +43,11 @@ variable "aws_agent_instance_type" {
   default = "m3.xlarge"
 }
 
+variable "aws_agent_instance_disk_size" {
+  description = "AWS DC/OS Private Agent instance type default size of the root disk (GB)"
+  default = "60"
+}
+
 variable "aws_public_agent_instance_type" {
   description = "AWS DC/OS Public instance type"
   default = "m3.xlarge"


### PR DESCRIPTION
The public agent node has a different functionality to the other nodes
in the cluster. So there should be an allowance to allocate a
different disk size for it compared to the rest of the nodes.

As per documentation:
https://dcos.io/docs/1.10/installing/custom/system-requirements/
the recommended minimum node disk size is 60GB which is what I've set
as the default size.