### PR TITLE
User AWS AMI map overrides that merge into dcos-tested-aws-oses.aws_ami

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -304,7 +304,8 @@ resource "aws_security_group" "private_slave" {
 
 # Provide tested AMI and user from listed region startup commands
   module "aws-tested-oses" {
-      source   = "./modules/dcos-tested-aws-oses"
-      os       = "${var.os}"
-      region   = "${var.aws_region}"
+      source        = "./modules/dcos-tested-aws-oses"
+      os            = "${var.os}"
+      region        = "${var.aws_region}"
+      user_aws_ami  = "${var.user_aws_ami}"
 }

--- a/aws/modules/dcos-tested-aws-oses/main.tf
+++ b/aws/modules/dcos-tested-aws-oses/main.tf
@@ -12,7 +12,7 @@ data "template_file" "aws_ami" {
   template = "$${aws_ami_result}"
 
   vars {
-    aws_ami_result = "${lookup(var.aws_ami, format("%s_%s",var.os, var.region))}"
+    aws_ami_result = "${lookup(merge(var.aws_ami, var.user_aws_ami), format("%s_%s",var.os, var.region))}"
   }
 }
 

--- a/aws/modules/dcos-tested-aws-oses/variables.tf
+++ b/aws/modules/dcos-tested-aws-oses/variables.tf
@@ -8,6 +8,11 @@ variable "aws_default_os_user" {
  }
 }
 
+variable "user_aws_ami" {
+  type = "map"
+  default = {}
+}
+
 # AWS recommends all HVM vs PV. HVM Below.
 variable "aws_ami" {
  type = "map"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -473,12 +473,17 @@ variable "dcos_ip_detect_public_contents" {
  description = "Used for AWS to determine the public IP. DC/OS bug requires this variable instead of a file see https://jira.mesosphere.com/browse/DCOS_OSS-905 for more information."
 }
 
-# Core OS
-variable "aws_amis" {
-  default = {
-    eu-west-1 = "ami-163e7e65"
-    us-east-1 = "ami-21732036"
-    us-west-1 = "ami-161a5176"
-    us-west-2 = "ami-078d5367"
-  }
+# A Map of AMI overrides for dcos-tested-aws-oses.  This is useful when you have
+# your own set of AMI's per region.  Convention for map key and values are:
+# {platform}_{platform version}_{aws region} = "{ami id}"
+#
+# Ex)
+# centos_7.2_ap-south-1          = "ami-95cda6fa"
+# centos_7.3_eu-west-1           = "ami-061b1560"
+# coreos_835.13.0_eu-west-1      = "ami-4b18aa38"
+# rhel_7.3_eu-west-2             = "ami-40a8bf24"
+variable "user_aws_ami" {
+ type = "map"
+ default = {}
+ description = "A Map of AMI overrides for dcos-tested-aws-oses module.  Convention for entries is: {platform}_{platform version}_{aws region} = \"{ami id}\""
 }


### PR DESCRIPTION
Allow the user to override or add additional AMI's per region and platform.  The new `user_aws_ami` map variable will be merged into the pre-existing `aws_ami` map of supported AMI's.