### PR TITLE
Change service account scopes for all instances on GCE

### DIFF
--- a/gcp/bootstrap.tf
+++ b/gcp/bootstrap.tf
@@ -60,7 +60,7 @@ resource "google_compute_instance" "bootstrap" {
   }
 
   service_account {
-      scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+      scopes = "${var.gcp_sa_scopes}"
   }
 }
 

--- a/gcp/master.tf
+++ b/gcp/master.tf
@@ -217,7 +217,7 @@ resource "google_compute_instance" "master" {
   }
 
   service_account {
-      scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+      scopes = "${var.gcp_sa_scopes}"
  }
 }
 

--- a/gcp/private-agent.tf
+++ b/gcp/private-agent.tf
@@ -99,7 +99,7 @@ resource "google_compute_instance" "agent" {
   }
 
   service_account {
-      scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+      scopes = "${var.gcp_sa_scopes}"
  }
 }
 

--- a/gcp/public-agent.tf
+++ b/gcp/public-agent.tf
@@ -149,7 +149,7 @@ resource "google_compute_instance" "public-agent" {
   }
 
   service_account {
-      scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+      scopes = "${var.gcp_sa_scopes}"
  }
 }
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -491,3 +491,8 @@ variable "dcos_ip_detect_public_contents" {
  default = "\"'#!/bin/sh\\n\\n  set -o nounset -o errexit\\n\\n\\n curl -fsSL http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H ''Metadata-Flavor: Google''\\n\\n   '\\n\""
  description = "Used for AWS to determine the public IP. DC/OS bug requires this variable instead of a file see https://jira.mesosphere.com/browse/DCOS_OSS-905 for more information."
 }
+
+variable "gcp_sa_scopes" {
+ description = "Scopes for GCE instances"
+ default = ["userinfo-email", "compute-ro", "storage-rw"]
+}


### PR DESCRIPTION
In order to setup service account scopes in GCP, we've had to add this new variable (I guess there will be much more but at the moment ...)