### PR TITLE
ssh_key_name duplicate fix

### DIFF
--- a/aws/desired_cluster_profile.tfvars.example
+++ b/aws/desired_cluster_profile.tfvars.example
@@ -11,4 +11,3 @@ aws_public_agent_instance_type = "m4.2xlarge"
 ssh_key_name = "default"
 # Inbound Master Access
 admin_cidr = "0.0.0.0/0"
-ssh_key_name = "default"


### PR DESCRIPTION
Removed duplicate entry of ssh_key_name = "default" in desired_cluster_profile.tfvars.example. 