### PR TITLE
AWS: Change root volume type to gp2

### DIFF
--- a/aws/bootstrap.tf
+++ b/aws/bootstrap.tf
@@ -13,6 +13,7 @@ resource "aws_instance" "bootstrap" {
 
   root_block_device {
     volume_size = "${var.aws_bootstrap_instance_disk_size}"
+    volume_type = "gp2"
   }
 
   instance_type = "${var.aws_bootstrap_instance_type}"

--- a/aws/master.tf
+++ b/aws/master.tf
@@ -127,6 +127,7 @@ resource "aws_instance" "master" {
 
   root_block_device {
     volume_size = "${var.aws_master_instance_disk_size}"
+    volume_type = "gp2"
   }
 
   count = "${var.num_of_masters}"

--- a/aws/private-agent.tf
+++ b/aws/private-agent.tf
@@ -13,6 +13,7 @@ resource "aws_instance" "agent" {
 
   root_block_device {
     volume_size = "${var.aws_agent_instance_disk_size}"
+    volume_type = "gp2"
   }
 
   count = "${var.num_of_private_agents}"

--- a/aws/public-agent.tf
+++ b/aws/public-agent.tf
@@ -55,6 +55,7 @@ resource "aws_instance" "public-agent" {
 
   root_block_device {
     volume_size = "${var.aws_public_agent_instance_disk_size}"
+    volume_type = "gp2"
   }
 
   count = "${var.num_of_public_agents}"


### PR DESCRIPTION
If we not specifying **volume_type** then **standard(magnetic)** type will be used and this is not the best type for root volume - it will impact performance.
We should specify **gp2** type for root volume.
https://www.terraform.io/docs/providers/aws/r/instance.html#volume_type