### PR TITLE
Allow disabling os-setup

### DIFF
--- a/aws/bootstrap.tf
+++ b/aws/bootstrap.tf
@@ -59,6 +59,9 @@ resource "aws_instance" "bootstrap" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -255,6 +258,9 @@ resource "null_resource" "bootstrap" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {

--- a/aws/bootstrap.tf
+++ b/aws/bootstrap.tf
@@ -57,7 +57,7 @@ resource "aws_instance" "bootstrap" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/aws/bootstrap.tf
+++ b/aws/bootstrap.tf
@@ -49,7 +49,7 @@ resource "aws_instance" "bootstrap" {
   # OS init script
   provisioner "file" {
    content = "${module.aws-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
    }
 
  # We run a remote provisioner on the instance after creating it.
@@ -57,8 +57,7 @@ resource "aws_instance" "bootstrap" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/aws/dcos-gpu-agents.tf.disabled
+++ b/aws/dcos-gpu-agents.tf.disabled
@@ -65,7 +65,7 @@ resource "aws_instance" "gpu-agent" {
 #  # OS init script
 #  provisioner "file" {
 #   source = "modules/dcos-tested-aws-oses/platform/cloud/aws/centos_7.2/setup.sh"
-#   destination = "/tmp/os-setup.sh"
+#   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
 #   }
 #
 # # We run a remote provisioner on the instance after creating it.
@@ -73,8 +73,7 @@ resource "aws_instance" "gpu-agent" {
 #  # this should be on port 80
 #    provisioner "remote-exec" {
 #    inline = [
-#      "sudo chmod +x /tmp/os-setup.sh",
-#      "sudo bash /tmp/os-setup.sh",
+#      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
 #    ]
 #  }
 

--- a/aws/dcos-gpu-agents.tf.disabled
+++ b/aws/dcos-gpu-agents.tf.disabled
@@ -71,10 +71,13 @@ resource "aws_instance" "gpu-agent" {
 # # We run a remote provisioner on the instance after creating it.
 #  # In this case, we just install nginx and start it. By default,
 #  # this should be on port 80
-#    provisioner "remote-exec" {
+#  provisioner "remote-exec" {
 #    inline = [
 #      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
 #    ]
+#    connection {
+#      script_path = "~/tmp_provision.sh"
+#    }
 #  }
 
   lifecycle {
@@ -122,6 +125,9 @@ resource "null_resource" "gpu-agent" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${aws_instance.bootstrap.private_ip}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Slave Node
@@ -130,6 +136,9 @@ resource "null_resource" "gpu-agent" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/aws/dcos-gpu-agents.tf.disabled
+++ b/aws/dcos-gpu-agents.tf.disabled
@@ -73,7 +73,7 @@ resource "aws_instance" "gpu-agent" {
 #  # this should be on port 80
 #  provisioner "remote-exec" {
 #    inline = [
-#      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+#      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
 #    ]
 #    connection {
 #      script_path = "~/tmp_provision.sh"

--- a/aws/desired_cluster_profile.tfvars.example
+++ b/aws/desired_cluster_profile.tfvars.example
@@ -1,13 +1,18 @@
-dcos_version = "1.11.7"
-num_of_masters = "3"
-num_of_private_agents = "3"
+dcos_version = "1.12.0"
+num_of_masters = "1"
+num_of_private_agents = "2"
 num_of_public_agents = "1"
 #
 aws_region = "us-west-2"
-aws_bootstrap_instance_type = "m3.large"
-aws_master_instance_type = "m4.2xlarge"
-aws_agent_instance_type = "m4.2xlarge"
-aws_public_agent_instance_type = "m4.2xlarge"
-ssh_key_name = "default"
+aws_bootstrap_instance_type = "m5.large"
+aws_master_instance_type = "m5.large"
+aws_agent_instance_type = "m5.large"
+aws_public_agent_instance_type = "m5.large"
+ssh_key_name = "cprovencher"
 # Inbound Master Access
 admin_cidr = "0.0.0.0/0"
+ssh_user = "centos"
+
+enable_os_setup_script = false
+aws_ami = "ami-0a80cc0a2ab2b090e"
+

--- a/aws/desired_cluster_profile.tfvars.example
+++ b/aws/desired_cluster_profile.tfvars.example
@@ -8,11 +8,10 @@ aws_bootstrap_instance_type = "m5.large"
 aws_master_instance_type = "m5.large"
 aws_agent_instance_type = "m5.large"
 aws_public_agent_instance_type = "m5.large"
-ssh_key_name = "cprovencher"
+ssh_key_name = "my_aws_ssh_key_name"
 # Inbound Master Access
 admin_cidr = "0.0.0.0/0"
 ssh_user = "centos"
 
 enable_os_setup_script = false
 aws_ami = "ami-0a80cc0a2ab2b090e"
-

--- a/aws/master.tf
+++ b/aws/master.tf
@@ -168,7 +168,7 @@ resource "aws_instance" "master" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/aws/master.tf
+++ b/aws/master.tf
@@ -155,7 +155,7 @@ resource "aws_instance" "master" {
   # OS init script
   provisioner "file" {
    content = "${module.aws-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
    }
 
   # We're going to launch into the same subnet as our ELB. In a production
@@ -168,8 +168,7 @@ resource "aws_instance" "master" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/aws/master.tf
+++ b/aws/master.tf
@@ -170,6 +170,9 @@ resource "aws_instance" "master" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -218,6 +221,9 @@ resource "null_resource" "master" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${aws_instance.bootstrap.private_ip}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Master Script
@@ -226,6 +232,9 @@ resource "null_resource" "master" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Watch Master Nodes Start
@@ -233,6 +242,9 @@ resource "null_resource" "master" {
     inline = [
       "until $(curl --output /dev/null --silent --head --fail http://${element(aws_instance.master.*.private_ip, count.index)}/); do printf 'loading DC/OS...'; sleep 10; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/aws/private-agent.tf
+++ b/aws/private-agent.tf
@@ -57,6 +57,9 @@ resource "aws_instance" "agent" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -106,6 +109,9 @@ resource "null_resource" "agent" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${aws_instance.bootstrap.private_ip}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Slave Node
@@ -114,6 +120,9 @@ resource "null_resource" "agent" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/aws/private-agent.tf
+++ b/aws/private-agent.tf
@@ -47,7 +47,7 @@ resource "aws_instance" "agent" {
   # OS init script
   provisioner "file" {
    content = "${module.aws-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
    }
 
  # We run a remote provisioner on the instance after creating it.
@@ -55,8 +55,7 @@ resource "aws_instance" "agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/aws/private-agent.tf
+++ b/aws/private-agent.tf
@@ -55,7 +55,7 @@ resource "aws_instance" "agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/aws/public-agent.tf
+++ b/aws/public-agent.tf
@@ -99,6 +99,9 @@ resource "aws_instance" "public-agent" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -149,6 +152,9 @@ resource "null_resource" "public-agent" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${aws_instance.bootstrap.private_ip}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Slave Node
@@ -157,6 +163,9 @@ resource "null_resource" "public-agent" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/aws/public-agent.tf
+++ b/aws/public-agent.tf
@@ -97,7 +97,7 @@ resource "aws_instance" "public-agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/aws/public-agent.tf
+++ b/aws/public-agent.tf
@@ -89,7 +89,7 @@ resource "aws_instance" "public-agent" {
   # OS init script
   provisioner "file" {
    content = "${module.aws-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
    }
 
  # We run a remote provisioner on the instance after creating it.
@@ -97,8 +97,7 @@ resource "aws_instance" "public-agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -494,3 +494,8 @@ variable "kubernetes_cluster" {
  default = "kubernetes-cluster"
  description = "Kubernetes cluster tag"
 }
+
+variable "enable_os_setup_script" {
+ default = true
+ description = "Call the os setup script"
+}

--- a/azure/bootstrap.tf
+++ b/azure/bootstrap.tf
@@ -191,7 +191,7 @@ resource "azurerm_virtual_machine" "bootstrap" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/bootstrap.tf
+++ b/azure/bootstrap.tf
@@ -200,6 +200,7 @@ resource "azurerm_virtual_machine" "bootstrap" {
     host = "${azurerm_public_ip.bootstrap_public_ip.fqdn}"
     private_key = "${local.private_key}"
     agent = "${local.agent}"
+    script_path = "~/tmp_provision.sh"
    }
  }
 
@@ -403,6 +404,9 @@ resource "null_resource" "bootstrap" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {

--- a/azure/bootstrap.tf
+++ b/azure/bootstrap.tf
@@ -175,7 +175,7 @@ resource "azurerm_virtual_machine" "bootstrap" {
   # OS init script
   provisioner "file" {
    content = "${module.azure-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
 
    connection {
     type = "ssh"
@@ -191,8 +191,7 @@ resource "azurerm_virtual_machine" "bootstrap" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/master.tf
+++ b/azure/master.tf
@@ -450,6 +450,7 @@ resource "azurerm_virtual_machine" "master" {
     host = "${element(azurerm_public_ip.master_public_ip.*.fqdn, count.index)}"
     private_key = "${local.private_key}"
     agent = "${local.agent}"
+    script_path = "~/tmp_provision.sh"
    }
  }
 
@@ -500,6 +501,9 @@ resource "null_resource" "master" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${azurerm_network_interface.bootstrap_nic.private_ip_address}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Master Script
@@ -508,6 +512,9 @@ resource "null_resource" "master" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Watch Master Nodes Start
@@ -515,6 +522,9 @@ resource "null_resource" "master" {
     inline = [
       "until $(curl --output /dev/null --silent --head --fail http://${element(azurerm_network_interface.master_nic.*.private_ip_address, count.index)}/); do printf 'loading DC/OS...'; sleep 10; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/azure/master.tf
+++ b/azure/master.tf
@@ -425,7 +425,7 @@ resource "azurerm_virtual_machine" "master" {
   # OS init script
   provisioner "file" {
    content = "${module.azure-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
 
    connection {
     type = "ssh"
@@ -441,8 +441,7 @@ resource "azurerm_virtual_machine" "master" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/master.tf
+++ b/azure/master.tf
@@ -441,7 +441,7 @@ resource "azurerm_virtual_machine" "master" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/private-agent.tf
+++ b/azure/private-agent.tf
@@ -177,7 +177,7 @@ resource "azurerm_virtual_machine" "agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/private-agent.tf
+++ b/azure/private-agent.tf
@@ -186,6 +186,7 @@ resource "azurerm_virtual_machine" "agent" {
     host = "${element(azurerm_public_ip.agent_public_ip.*.fqdn, count.index)}"
     private_key = "${local.private_key}"
     agent = "${local.agent}"
+    script_path = "~/tmp_provision.sh"
    }
  }
 
@@ -236,6 +237,9 @@ resource "null_resource" "agent" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${azurerm_network_interface.bootstrap_nic.private_ip_address}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Agent Script
@@ -244,6 +248,9 @@ resource "null_resource" "agent" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/azure/private-agent.tf
+++ b/azure/private-agent.tf
@@ -161,7 +161,7 @@ resource "azurerm_virtual_machine" "agent" {
   # OS init script
   provisioner "file" {
    content = "${module.azure-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
 
    connection {
     type = "ssh"
@@ -177,8 +177,7 @@ resource "azurerm_virtual_machine" "agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/public-agent.tf
+++ b/azure/public-agent.tf
@@ -334,7 +334,7 @@ resource "azurerm_virtual_machine" "public-agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/public-agent.tf
+++ b/azure/public-agent.tf
@@ -343,6 +343,7 @@ resource "azurerm_virtual_machine" "public-agent" {
     host = "${element(azurerm_public_ip.public_agent_public_ip.*.fqdn, count.index)}"
     private_key = "${local.private_key}"
     agent = "${local.agent}"
+    script_path = "~/tmp_provision.sh"
    }
  }
 
@@ -393,6 +394,9 @@ resource "null_resource" "public-agent" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${azurerm_network_interface.bootstrap_nic.private_ip_address}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Public Agent Script
@@ -401,6 +405,9 @@ resource "null_resource" "public-agent" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/azure/public-agent.tf
+++ b/azure/public-agent.tf
@@ -318,7 +318,7 @@ resource "azurerm_virtual_machine" "public-agent" {
   # OS init script
   provisioner "file" {
    content = "${module.azure-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
 
    connection {
     type = "ssh"
@@ -334,8 +334,7 @@ resource "azurerm_virtual_machine" "public-agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
 
    connection {

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -453,3 +453,8 @@ variable "dcos_ip_detect_public_contents" {
  default = "\"'#!/bin/sh\\n\\n  curl -H Metadata:true -fsSL \\\"http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-04-02&format=text\\\"\\n\\n   '\\n\""
  description = "Used for AWS to determine the public IP. Note: single quotes was subsututed for hex x27 as it cannot be used. Currently escapes will need to be performed twice. DC/OS bug requires this variable instead of a file see https://jira.mesosphere.com/browse/DCOS_OSS-905 for more information."
 }
+
+variable "enable_os_setup_script" {
+ default = true
+ description = "Call the os setup script"
+}

--- a/ci_smoke_test.sh
+++ b/ci_smoke_test.sh
@@ -8,14 +8,11 @@ set -euxo pipefail
 ssh-keygen -f id_rsa -t rsa -N ''
 chmod 600 id_rsa
 
-# download the latest terraform binary in the current working directory
-terraform_latest_version=$(curl -s "https://api.github.com/repos/hashicorp/terraform/releases/latest" | grep "tag_name" | grep -Po "(\d|\.)+")
-base_url="https://releases.hashicorp.com/terraform/{version}/terraform_{version}_linux_amd64.zip"
-terraform_download_url=$(echo ${base_url} | sed "s/{version}/$terraform_latest_version/g")
-zip="terraform.zip"
-wget --output-document="$zip" "$terraform_download_url"
-unzip "$zip"
-rm "$zip"
+# Download the terraform binary in the current directory
+wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
+unzip ./terraform*.zip
+chmod +x terraform
+rm ./terraform*.zip
 
 if [[ ! -v TERRAFORM_PATH ]]
 then

--- a/gcp/bootstrap.tf
+++ b/gcp/bootstrap.tf
@@ -37,7 +37,7 @@ resource "google_compute_instance" "bootstrap" {
   # OS init script
   provisioner "file" {
    content = "${module.dcos-tested-gcp-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
  }
 
   # We run a remote provisioner on the instance after creating it.
@@ -45,8 +45,7 @@ resource "google_compute_instance" "bootstrap" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/gcp/bootstrap.tf
+++ b/gcp/bootstrap.tf
@@ -47,6 +47,9 @@ resource "google_compute_instance" "bootstrap" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -258,6 +261,9 @@ resource "null_resource" "bootstrap" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {

--- a/gcp/bootstrap.tf
+++ b/gcp/bootstrap.tf
@@ -45,7 +45,7 @@ resource "google_compute_instance" "bootstrap" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/gcp/master.tf
+++ b/gcp/master.tf
@@ -194,7 +194,7 @@ resource "google_compute_instance" "master" {
   # OS init script
   provisioner "file" {
    content = "${module.dcos-tested-gcp-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
    }
 
   # We run a remote provisioner on the instance after creating it.
@@ -202,8 +202,7 @@ resource "google_compute_instance" "master" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/gcp/master.tf
+++ b/gcp/master.tf
@@ -202,7 +202,7 @@ resource "google_compute_instance" "master" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/gcp/master.tf
+++ b/gcp/master.tf
@@ -204,6 +204,9 @@ resource "google_compute_instance" "master" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -262,6 +265,9 @@ resource "null_resource" "master" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${google_compute_instance.bootstrap.network_interface.0.address}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Master Script
@@ -270,6 +276,9 @@ resource "null_resource" "master" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Watch Master Nodes Start
@@ -277,6 +286,9 @@ resource "null_resource" "master" {
     inline = [
       "until $(curl --output /dev/null --silent --head --fail http://${element(google_compute_instance.master.*.network_interface.0.address, count.index)}/); do printf 'loading DC/OS...'; sleep 10; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/gcp/private-agent.tf
+++ b/gcp/private-agent.tf
@@ -86,6 +86,9 @@ resource "google_compute_instance" "agent" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -144,6 +147,9 @@ resource "null_resource" "agent" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${google_compute_instance.bootstrap.network_interface.0.address}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Agent Script
@@ -152,6 +158,9 @@ resource "null_resource" "agent" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/gcp/private-agent.tf
+++ b/gcp/private-agent.tf
@@ -84,7 +84,7 @@ resource "google_compute_instance" "agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/gcp/private-agent.tf
+++ b/gcp/private-agent.tf
@@ -76,7 +76,7 @@ resource "google_compute_instance" "agent" {
   # OS init script
   provisioner "file" {
    content = "${module.dcos-tested-gcp-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
    }
 
  # We run a remote provisioner on the instance after creating it.
@@ -84,8 +84,7 @@ resource "google_compute_instance" "agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/gcp/public-agent.tf
+++ b/gcp/public-agent.tf
@@ -126,7 +126,7 @@ resource "google_compute_instance" "public-agent" {
   # OS init script
   provisioner "file" {
    content = "${module.dcos-tested-gcp-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
+   destination = "${var.enable_os_setup_script ? "/usr/local/sbin/os-setup.sh" : "/dev/null"}"
    }
 
  # We run a remote provisioner on the instance after creating it.
@@ -134,8 +134,7 @@ resource "google_compute_instance" "public-agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "sudo chmod +x /tmp/os-setup.sh",
-      "sudo bash /tmp/os-setup.sh",
+      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
   }
 

--- a/gcp/public-agent.tf
+++ b/gcp/public-agent.tf
@@ -136,6 +136,9 @@ resource "google_compute_instance" "public-agent" {
     inline = [
       "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   lifecycle {
@@ -194,6 +197,9 @@ resource "null_resource" "public-agent" {
     inline = [
      "until $(curl --output /dev/null --silent --head --fail http://${google_compute_instance.bootstrap.network_interface.0.address}:${var.custom_dcos_bootstrap_port}/dcos_install.sh); do printf 'waiting for bootstrap node to serve...'; sleep 20; done"
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 
   # Install Public Agent Script
@@ -202,6 +208,9 @@ resource "null_resource" "public-agent" {
       "sudo chmod +x run.sh",
       "sudo ./run.sh",
     ]
+    connection {
+      script_path = "~/tmp_provision.sh"
+    }
   }
 }
 

--- a/gcp/public-agent.tf
+++ b/gcp/public-agent.tf
@@ -134,7 +134,7 @@ resource "google_compute_instance" "public-agent" {
   # this should be on port 80
     provisioner "remote-exec" {
     inline = [
-      "if [ -f /usr/local/sbin/os-setup.sh ]; then sudo chmod +x /usr/local/sbin/os-setup.sh && sudo bash /usr/local/sbin/os-setup.sh; fi"
+      "if [ -f ~/os-setup.sh ]; then sudo chmod +x ~/os-setup.sh && sudo bash ~/os-setup.sh; fi"
     ]
     connection {
       script_path = "~/tmp_provision.sh"

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -491,3 +491,8 @@ variable "dcos_ip_detect_public_contents" {
  default = "\"'#!/bin/sh\\n\\n  set -o nounset -o errexit\\n\\n\\n curl -fsSL http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H ''Metadata-Flavor: Google''\\n\\n   '\\n\""
  description = "Used for AWS to determine the public IP. DC/OS bug requires this variable instead of a file see https://jira.mesosphere.com/browse/DCOS_OSS-905 for more information."
 }
+
+variable "enable_os_setup_script" {
+ default = true
+ description = "Call the os setup script"
+}


### PR DESCRIPTION
- Add a boolean variable to allow skipping the os setup script
- make terraform-dcos compatible with AMIs that have /tmp set to noexec